### PR TITLE
Fix a warning in Elixir 1.16

### DIFF
--- a/lib/map_to_xml.ex
+++ b/lib/map_to_xml.ex
@@ -130,7 +130,8 @@ defmodule MapToXml do
     if Enum.member?(keys, "#content") do
       attributes =
         for key <- keys, String.slice(key, 0, 1) == "-", into: %{} do
-          {String.slice(key, 1..-1), map[key]}
+          last_char_pos = max(String.length(key) - 1, 0)
+          {String.slice(key, 1, last_char_pos), map[key]}
         end
 
       build_tag(key, map["#content"], attributes)


### PR DESCRIPTION
In Elixir 1.16 calls like `String.slice(key, 1..-1)` produce warnings:
```
warning: negative steps are not supported in String.slice/2, pass 1..-1//1 instead
```

`1..-1//1` option is not suitable for people on Elixir < 1.12, so here I use `String.slice/3`.